### PR TITLE
fix(math): Missing functions and few compile and docs issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,25 @@ SaturnMath++ is designed specifically for the Sega Saturn's hardware constraints
 - Compile-time optimizations with constexpr/consteval
 - Zero dynamic memory allocation
 
+## Architecture
+
+SaturnMath++ is organized into two main namespaces:
+
+### SaturnMath::Types
+Contains all fundamental mathematical types and structures:
+- Vector arithmetic (`Vector2D`, `Vector3D`)
+- Matrix operations (`Mat33`, `Matrix43`)
+- Geometric primitives (`AABB`, `Sphere`, `Plane`, `Frustum`)
+- Fixed-point numbers (`Fxp`)
+- Angle representation optimized for Saturn hardware
+
+### SaturnMath
+Provides mathematical operations and utilities:
+- Trigonometric functions
+- Interpolation methods
+- Integer-specific optimizations
+- Template-based utility functions for common operations (Min, Max, Abs, Clamp)
+
 ## Features
 
 ### Core Components
@@ -101,7 +120,7 @@ Just include the library in your Sega Saturn project:
 
 ```cpp
 #include "saturn_math.hpp"
-using namespace SaturnMath;
+using namespace SaturnMath::Types;
 
 // 3D vector operations with different precision levels
 Vector3D position(1, 2, 3);
@@ -148,18 +167,26 @@ Vector3D v1(0, 0, 0), v2(1, 0, 0), v3(0, 1, 0);
 Vector3D normal = Vector3D::CalcNormal<Precision::Standard>(v1, v2, v3);
 Vector3D fastNormal = Vector3D::CalcNormal<Precision::Fast>(v1, v2, v3);
 
+// Collision detection
+Sphere sphere(center, 2.0_fxp);
+bool collision = box.Intersects(sphere);
+
 // Create view matrix with precision control
 Vector3D eye(0, 5, -10);
 Vector3D target(0, 0, 0);
 Vector3D up = Vector3D::UnitY();
 Matrix43 view = Matrix43::CreateLookAt<Precision::Standard>(eye, target, up);
+
+// Frustum culling
+Frustum viewFrustum;
+bool isVisible = viewFrustum.Contains(box);
 ```
 
 ### Fixed-Point and Angle Operations
 
 ```cpp
 #include "saturn_math.hpp"
-using namespace SaturnMath;
+using namespace SaturnMath::Types;
 
 // Fixed-point arithmetic
 Fxp a(5);                   // 5 (0x00050000)
@@ -173,21 +200,21 @@ Fxp clamped = b.Clamp(0, 2); // 2
 
 // Angle calculations
 Angle rotation = Angle::FromDegrees(45);
-Fxp sine = Sin(rotation);
-Fxp cosine = Cos(rotation);
+Fxp sine = SaturnMath::Sin(rotation);
+Fxp cosine = SaturnMath::Cos(rotation);
 
 // Example of angle arithmetic
 Angle doubled = rotation * Fxp(2);    // Double the angle
 Angle halved = rotation / Fxp(2);     // Half the angle
 
 // Euler angles for 3D rotation
-EulerAngles orientation(
+Vector3D orientation(
     Angle::FromDegrees(30),  // Pitch
     Angle::FromDegrees(45),  // Yaw
     Angle::FromDegrees(0)    // Roll
 );
 
-// Create transformation matrix from Euler angles
+// Create transformation matrix from angles
 Matrix43 transform = Matrix43::CreateTransform(
     Vector3D(1, 2, 3),      // Translation
     orientation,             // Rotation
@@ -204,7 +231,13 @@ Matrix43 billboard = Matrix43::CreateBillboard(
 // Smooth angle interpolation
 Angle start = Angle::Zero();
 Angle end = Angle::HalfPi();
-Angle interpolated = Trigonometry::SLerp(start, end, Fxp(0.5));
+Angle interpolated = SaturnMath::Interpolation::SLerp(start, end, Fxp(0.5));
+
+// Utility functions
+using namespace SaturnMath;
+auto maxVal = Max(5_fxp, 3_fxp);
+auto absVal = Abs(-5_fxp);
+auto clampedVal = Clamp(7_fxp, 0_fxp, 5_fxp);
 ```
 
 ## Performance Considerations

--- a/README.md
+++ b/README.md
@@ -39,10 +39,28 @@ Provides mathematical operations and utilities:
   - Power function for integer exponents
   - Value clamping between bounds
   - Comprehensive arithmetic operations
+  - Flexible value conversion:
+    ```cpp
+    // Compile-time conversion (preferred)
+    constexpr Fxp a = 3.14159;   // Exact conversion at compile-time
+
+    // Integer conversion with range checking
+    Fxp b = Fxp::Convert(100);   // Checks if value fits in int16_t range
+
+    // Floating-point conversion (will warn about performance)
+    Fxp c = Fxp::Convert(3.14f); // Warning: heavy operation
+    Fxp d = Fxp::Convert(2.5);   // Warning: heavy operation
+
+    // Manual casting (advanced users only)
+    Fxp e = static_cast<int32_t>(someValue << 16); // No warnings, but risks overflow
+    ```
+  - **Manual Casting**: For advanced users who understand the risks of precision loss or overflow, manual casting is allowed. However, use the `Convert` function for safer conversions.
+
 - **Angle Handling**: Type-safe `Angle` class for angular calculations
   - Raw value construction and access
   - Scalar multiplication and division
   - Automatic wrap-around handling
+
 - **Euler Angles**: Type-safe representation of 3D rotations
   - Intrinsic Tait-Bryan angles (pitch-yaw-roll)
   - X-Y-Z rotation order
@@ -189,10 +207,10 @@ bool isVisible = viewFrustum.Contains(box);
 using namespace SaturnMath::Types;
 
 // Fixed-point arithmetic
-Fxp a(5);                   // 5 (0x00050000)
-Fxp b(2.5);                // 2.5 (0x00028000)
-Fxp c = a * b;             // 12.5 (0x000C8000)
-int16_t i = c.ToInt();     // 12
+Fxp a(5);                     // 5 (0x00050000)
+Fxp b(2.5);                   // 2.5 (0x00028000)
+Fxp c = a * b;                // 12.5 (0x000C8000)
+int16_t i = c.As<int16_t>();  // 12
 
 // Power and clamping operations
 Fxp squared = a.Pow(2);    // 25

--- a/impl/aabb.hpp
+++ b/impl/aabb.hpp
@@ -5,7 +5,7 @@
 #include "shape.hpp"
 #include <array>
 
-namespace SaturnMath
+namespace SaturnMath::Types
 {
     class AABB : public Shape
     {

--- a/impl/angle.hpp
+++ b/impl/angle.hpp
@@ -3,7 +3,7 @@
 #include "fxp.hpp"
 #include <numbers>
 
-namespace SaturnMath
+namespace SaturnMath::Types
 {
     /**
      * @brief Efficient 16-bit angle representation optimized for Saturn hardware.

--- a/impl/angle.hpp
+++ b/impl/angle.hpp
@@ -145,7 +145,7 @@ namespace SaturnMath::Types
           */
         constexpr Angle operator+(const Angle& other) const
         {
-            return Angle(value + other.RawValue()); // Natural 16-bit wrap-around
+            return Angle(value + other.value); // Natural 16-bit wrap-around
         }
 
         /**
@@ -155,7 +155,7 @@ namespace SaturnMath::Types
          */
         constexpr Angle operator-(const Angle& other) const
         {
-            return Angle(value - other.RawValue()); // Natural 16-bit wrap-around
+            return Angle(value - other.value); // Natural 16-bit wrap-around
         }
 
         /**
@@ -203,6 +203,30 @@ namespace SaturnMath::Types
         {
             return Angle((ToFxp() / fxp).RawValue());
         }
+        /**
+         * @brief Adds two angles.
+         * @param other Angle to add
+         * @return Reference to the modified Angle object
+         * @note Automatically wraps around the result
+         */
+        constexpr Angle& operator+=(const Angle& other)
+        {
+            value += other.value; // Natural 16-bit wrap-around
+            return *this;
+        }
+
+        /**
+         * @brief Subtracts two angles.
+         * @param other Angle to subtract
+         * @return Reference to the modified Angle object
+         * @note Automatically wraps around the result
+         */
+        constexpr Angle& operator-=(const Angle& other)
+        {
+            value -= other.value; // Natural 16-bit wrap-around
+            return *this;
+        }
+
         /** @} */
     };
 

--- a/impl/frustum.hpp
+++ b/impl/frustum.hpp
@@ -5,7 +5,7 @@
 #include "aabb.hpp"
 #include "sphere.hpp"
 
-namespace SaturnMath
+namespace SaturnMath::Types
 {
     /**
      * @brief View frustum for camera culling in 3D space.

--- a/impl/fxp.hpp
+++ b/impl/fxp.hpp
@@ -5,7 +5,7 @@
 #include <concepts>
 #include "precision.hpp"
 
-namespace SaturnMath
+namespace SaturnMath::Types
 {
     /**
      * @brief Fixed-point arithmetic optimized for Saturn hardware.

--- a/impl/fxp.hpp
+++ b/impl/fxp.hpp
@@ -220,7 +220,7 @@ namespace SaturnMath
                 }
 
                 root >>= 8;
-                return static_cast<int32_t>(root);
+                return BuildRaw(root);
             }
             else // Precision::Fast or Precision::Turbo
             {

--- a/impl/fxp.hpp
+++ b/impl/fxp.hpp
@@ -334,13 +334,13 @@ namespace SaturnMath
 
         /**
          * @brief Power function for fixed-point numbers.
-         * 
+         *
          * Calculates this value raised to the power of exponent.
          * Uses repeated multiplication for integer exponents.
-         * 
+         *
          * @param exponent The power to raise this value to
          * @return The result of this^exponent
-         * 
+         *
          * @note Only supports non-negative integer exponents for efficiency
          */
         constexpr Fxp Pow(const Fxp& exponent) const
@@ -348,12 +348,12 @@ namespace SaturnMath
             // Handle special cases
             if (exponent == 0) return 1;
             if (exponent == 1) return *this;
-            
+
             // Convert to integer for efficient calculation
             int32_t intExp = exponent.RawValue() >> 16;
             Fxp result(1);
             Fxp base = *this;
-            
+
             while (intExp > 0)
             {
                 if (intExp & 1)
@@ -361,13 +361,13 @@ namespace SaturnMath
                 base = base * base;
                 intExp >>= 1;
             }
-            
+
             return result;
         }
 
         /**
          * @brief Clamps this value between minimum and maximum bounds.
-         * 
+         *
          * @param min Minimum allowed value
          * @param max Maximum allowed value
          * @return Clamped value
@@ -425,7 +425,58 @@ namespace SaturnMath
         }
 
         /**
-         * @brief Fixed-point division (a /= b).
+         * @brief Multiplies the current fixed-point value by an integer (a *= b).
+         * @tparam T The type of the integer (e.g., int, int32_t).
+         * @param value The integer value to multiply with.
+         * @return A reference to this object after performing the multiplication,
+         *         allowing for chaining of operations.
+         *
+         * @note This operation modifies the current instance in place. Ensure that
+         *       the input value is within the valid range to avoid overflow.
+         */
+        template<typename T>
+            requires std::is_integral_v<T>
+        constexpr Fxp& operator*=(const T& value)
+        {
+            value *= value;
+            return *this;
+        }
+
+        /**
+         * @brief Multiplies the current fixed-point value by an integer (a * b).
+         * @tparam T The type of the integer (e.g., int, int32_t).
+         * @param value The integer value to multiply with.
+         * @return The product as a new Fxp object.
+         *
+         * @note This operation does not modify the current instance. It returns a new
+         *       Fxp object representing the result of the multiplication.
+         */
+        template<typename T>
+            requires std::is_integral_v<T>
+        constexpr Fxp operator*(const T& value) const
+        {
+            return BuildRaw(value * this->value);
+        }
+
+        /**
+         * @brief Multiplies an integer by a fixed-point value (lhs * rhs).
+         * @tparam T The type of the integer (e.g., int, int32_t).
+         * @param lhs The integer value to multiply.
+         * @param rhs The fixed-point value to multiply with.
+         * @return The product as a new Fxp object.
+         *
+         * @note This operation does not modify the current instance. It returns a new
+         *       Fxp object representing the result of the multiplication.
+         */
+        template<typename T>
+            requires std::is_integral_v<T>
+        constexpr friend Fxp operator*(T lhs, const Fxp& rhs)
+        {
+            return rhs * lhs;
+        }
+
+        /**
+         * @brief Divides the current fixed-point value by another fixed-point value (a /= b).
          *
          * Uses Saturn's hardware divider unit at runtime for optimal performance.
          * Falls back to double math at compile time.
@@ -450,13 +501,61 @@ namespace SaturnMath
         }
 
         /**
-         * @brief Fixed-point division (a / b).
+         * @brief Divides the current fixed-point value by another fixed-point value (a / b).
          * @param fxp Value to divide by
          * @return Quotient as Fxp
          */
         constexpr Fxp operator/(const Fxp& fxp) const
         {
             return Fxp(*this) /= fxp;
+        }
+
+        /**
+         * @brief Divides the current fixed-point value by an integer (a /= b).
+         * @tparam T The type of the integer (e.g., int, int32_t).
+         * @param value The integer value to divide by.
+         * @return A reference to this object after performing the division,
+         *         allowing for chaining of operations.
+         *
+         * @note This operation modifies the current instance in place. Ensure that
+         *       the input value is non-zero to avoid division by zero errors.
+         */
+        template<typename T>
+            requires std::is_integral_v<T>
+        constexpr Fxp& operator/=(const T& value)
+        {
+            value /= value;
+            return *this;
+        }
+
+        /**
+         * @brief Divides the current fixed-point value by an integer (a / b).
+         * @tparam T The type of the integer (e.g., int, int32_t).
+         * @param value The integer value to divide by.
+         * @return The quotient as a new Fxp object.
+         *
+         * @note This operation does not modify the current instance. It returns a new
+         *       Fxp object representing the result of the division.
+         */
+        template<typename T>
+            requires std::is_integral_v<T>
+        constexpr Fxp operator/(const T& value) const
+        {
+            return BuildRaw(this->value / value);
+        }
+
+        /**
+         * @brief Divides an integer by a fixed-point value (lhs / rhs).
+         * @param lhs The integer value to divide.
+         * @param rhs The fixed-point value to divide by.
+         * @return The quotient as a new Fxp object.
+         *
+         * @note This operation does not modify the current instance. It returns a new
+         *       Fxp object representing the result of the division.
+         */
+        constexpr friend Fxp operator/(const int16_t& lhs, const Fxp& rhs)
+        {
+            return Fxp(lhs) / rhs;
         }
 
         /**

--- a/impl/fxp.hpp
+++ b/impl/fxp.hpp
@@ -36,7 +36,7 @@ namespace SaturnMath
      * @note All operations are designed for maximum efficiency on Saturn hardware.
      *       Avoid runtime floating-point conversions in performance-critical code.
      *
-     * @note The #pragma GCC optimize("O2") directive is used to enable optimizations that improve performance,
+     * @note The \#pragma GCC optimize("O2") directive is used to enable optimizations that improve performance,
      *       specifically for fixed-point arithmetic operations. It ensures that the compiler generates efficient
      *       code that takes full advantage of the hardware capabilities, particularly in performance-critical sections.
      *       Without this optimization, the generated code may not perform as expected, leading to slower execution.
@@ -283,14 +283,21 @@ namespace SaturnMath
          * @brief Extracts integer part.
          * @return Integer portion of value
          */
-        constexpr int16_t ToInt() { return static_cast<int16_t>(value >> 16); }
+        constexpr int16_t ToInt() const { return static_cast<int16_t>(value >> 16); }
+
+        /**
+         * @brief Converts to float.
+         * @return Float value
+         * @note Only available at compile time due to consteval
+         */
+        consteval float ToFloat() const { return value / 65536.0f; }
 
         /**
          * @brief Converts to double.
          * @return Double value
          * @note Only available at compile time due to consteval
          */
-        consteval double ToFloat() { return value / 65536.0; }
+        consteval double ToDouble() const { return value / 65536.0; }
 
         /**
          * @brief Clears the MAC (Multiply-and-Accumulate) registers.
@@ -454,7 +461,6 @@ namespace SaturnMath
 
         /**
          * @brief Copy assignment operator.
-         * @param fxp The Fxp object to copy.
          * @return A reference to this object.
          */
         constexpr Fxp& operator=(const Fxp&) = default;
@@ -549,7 +555,5 @@ namespace SaturnMath
          */
         constexpr Fxp& operator<<=(const size_t& shiftAmount) { value <<= shiftAmount; return *this; }
     };
-
-    static constexpr auto test = Fxp(0.3).Pow(3).ToFloat();
 }
 #pragma GCC reset_options

--- a/impl/interpolation.hpp
+++ b/impl/interpolation.hpp
@@ -5,6 +5,7 @@
 
 namespace SaturnMath
 {
+    using namespace SaturnMath::Types;
     /**
      * @brief Class containing interpolation and easing functions optimized for fixed-point arithmetic.
      *

--- a/impl/mat33.hpp
+++ b/impl/mat33.hpp
@@ -56,11 +56,12 @@ namespace SaturnMath
          *
          * @note Ensure that up and direction vectors are not collinear to avoid undefined behavior.
          *
-         * @example
+         * @code {.cpp}
          * Matrix33 rotation = Matrix33(
          *     Vector3D(0, 1, 0),    // Up vector
          *     Vector3D(0, 0, 1)     // Direction vector
          * );
+         * @endcode 
          */
         constexpr Matrix33(const Vector3D& up, const Vector3D& direction) : Row0(up.Cross(direction)), Row1(up), Row2(direction) {}
 
@@ -76,12 +77,13 @@ namespace SaturnMath
          *
          * @note For proper rotation matrices, ensure the row vectors are orthonormal.
          *
-         * @example
+         * @code {.cpp}
          * Matrix33 matrix = Matrix33(
          *     Vector3D(1, 0, 0),    // Right vector
          *     Vector3D(0, 1, 0),    // Up vector
          *     Vector3D(0, 0, 1)     // Forward vector
          * );
+         * @endcode 
          */
         constexpr Matrix33(const Vector3D& row0In, const Vector3D& row1In, const Vector3D& row2In) : Row0(row0In), Row1(row1In), Row2(row2In) {}
 
@@ -97,10 +99,11 @@ namespace SaturnMath
          *
          * @note Matrix multiplication is not commutative, meaning A * B ≠ B * A.
          *
-         * @example
+         * @code {.cpp}
          * Matrix33 matA = Matrix33::CreateRotationX(Angle::FromDegrees(90));
          * Matrix33 matB = Matrix33::CreateRotationY(Angle::FromDegrees(45));
          * matA *= matB; // Combines rotations, first X then Y
+         * @endcode 
          */
         Matrix33& operator*=(const Matrix33& other)
         {
@@ -130,8 +133,9 @@ namespace SaturnMath
          *
          * @note This is equivalent to creating a copy of this matrix and using operator*=.
          *
-         * @example
+         * @code {.cpp}
          * Matrix33 combined = rotationMatrix * scaleMatrix;
+         * @endcode 
          */
         Matrix33 operator*(const Matrix33& other) const
         {
@@ -154,10 +158,11 @@ namespace SaturnMath
          *
          * @note For a rotation matrix, the length of the input vector is preserved.
          *
-         * @example
+         * @code {.cpp}
          * Vector3D direction(0, 0, 1);
          * Matrix33 rotation = Matrix33::CreateRotationY(Angle::FromDegrees(90));
          * Vector3D rotated = rotation * direction; // Rotates the vector 90° around Y axis
+         * @endcode 
          */
         Vector3D operator*(const Vector3D& v) const 
         { 
@@ -180,9 +185,10 @@ namespace SaturnMath
          * @note For orthogonal matrices (like pure rotation matrices), 
          * the transpose is equal to the inverse.
          *
-         * @example
+         * @code {.cpp}
          * Matrix33 mat = Matrix33::CreateRotationX(Angle::FromDegrees(45));
          * mat.Transpose(); // Transposes the matrix in-place
+         * @endcode 
          */
         Matrix33& Transpose()
         {
@@ -221,9 +227,10 @@ namespace SaturnMath
          * @note This is ideal for continuous transformations like animation
          * as it modifies the existing matrix rather than creating a new one.
          *
-         * @example
+         * @code {.cpp}
          * Matrix33 transform = Matrix33::Identity();
          * transform.RotateX(Angle::FromDegrees(45)); // Rotate 45° around X
+         * @endcode 
          */
         Matrix33& RotateX(const Angle& angleX)
         {
@@ -266,9 +273,10 @@ namespace SaturnMath
          * @param angle Rotation angle around X-axis.
          * @return A new rotation matrix.
          *
-         * @example
+         * @code {.cpp}
          * Matrix33 rotation = Matrix33::CreateRotationX(Angle::FromDegrees(90));
          * Vector3D rotated = rotation * Vector3D(0, 1, 0); // Rotates (0,1,0) to (0,0,1)
+         * @endcode 
          */
         static constexpr Matrix33 CreateRotationX(const Angle& angle)
         {
@@ -298,9 +306,10 @@ namespace SaturnMath
          * @note This is ideal for continuous transformations like animation
          * as it modifies the existing matrix rather than creating a new one.
          *
-         * @example
+         * @code {.cpp}
          * Matrix33 transform = Matrix33::Identity();
          * transform.RotateY(Angle::FromDegrees(45)); // Rotate 45° around Y
+         * @endcode 
          */
         Matrix33& RotateY(const Angle& angleY)
         {
@@ -341,9 +350,10 @@ namespace SaturnMath
          * @param angle Rotation angle around Y-axis.
          * @return A new rotation matrix.
          *
-         * @example
+         * @code {.cpp}
          * Matrix33 rotation = Matrix33::CreateRotationY(Angle::FromDegrees(90));
          * Vector3D rotated = rotation * Vector3D(1, 0, 0); // Rotates (1,0,0) to (0,0,-1)
+         * @endcode 
          */
         static constexpr Matrix33 CreateRotationY(const Angle& angle)
         {
@@ -374,9 +384,10 @@ namespace SaturnMath
          * @note This is ideal for continuous transformations like animation
          * as it modifies the existing matrix rather than creating a new one.
          *
-         * @example
+         * @code {.cpp}
          * Matrix33 transform = Matrix33::Identity();
          * transform.RotateZ(Angle::FromDegrees(45)); // Rotate 45° around Z
+         * @endcode 
          */
         Matrix33& RotateZ(const Angle& angleZ)
         {
@@ -417,9 +428,10 @@ namespace SaturnMath
          * @param angle Rotation angle around Z-axis.
          * @return A new rotation matrix.
          *
-         * @example
+         * @code {.cpp}
          * Matrix33 rotation = Matrix33::CreateRotationZ(Angle::FromDegrees(90));
          * Vector3D rotated = rotation * Vector3D(1, 0, 0); // Rotates (1,0,0) to (0,1,0)
+         * @endcode 
          */
         static constexpr Matrix33 CreateRotationZ(const Angle& angle)
         {
@@ -454,12 +466,13 @@ namespace SaturnMath
          * @note The order of rotations matters. Changing the order will result
          * in a different final orientation.
          *
-         * @example
+         * @code {.cpp}
          * Matrix33 rotation = Matrix33::CreateRotation(
          *     Angle::FromDegrees(30),  // X rotation (pitch)
          *     Angle::FromDegrees(45),  // Y rotation (yaw)
          *     Angle::FromDegrees(60)   // Z rotation (roll)
          * );
+         * @endcode 
          */
         static constexpr Matrix33 CreateRotation(const Angle& angleX, const Angle& angleY, const Angle& angleZ)
         {
@@ -505,9 +518,10 @@ namespace SaturnMath
          * @note This operation affects both the orientation and scale of the transformation.
          * For pure scaling, use CreateScale instead.
          *
-         * @example
+         * @code {.cpp}
          * Matrix33 transform = Matrix33::Identity();
          * transform.Scale(Vector3D(2, 1, 0.5)); // Scale x by 2, y by 1, z by 0.5
+         * @endcode 
          */
         Matrix33& Scale(const Vector3D& scale)
         {
@@ -544,9 +558,10 @@ namespace SaturnMath
          * - det = 1 for pure rotation matrices
          * - |det| represents the scale factor of the transformation
          *
-         * @example
+         * @code {.cpp}
          * Matrix33 rotation = Matrix33::CreateRotationX(Angle::FromDegrees(90));
          * Fxp det = rotation.Determinant(); // Should be close to 1
+         * @endcode 
          */
         constexpr Fxp Determinant() const
         {
@@ -575,12 +590,13 @@ namespace SaturnMath
          * @note For orthogonal matrices (like pure rotation matrices),
          * the inverse is equal to the transpose.
          *
-         * @example
+         * @code {.cpp}
          * Matrix33 transform = Matrix33::CreateRotationY(Angle::FromDegrees(45));
          * Matrix33 inverse;
          * if (transform.TryInverse(inverse)) {
          *     // inverse * transform ≈ Identity
          * }
+         * @endcode 
          */
         bool TryInverse(Matrix33& out) const
         {
@@ -622,9 +638,10 @@ namespace SaturnMath
          * @note Unlike the Scale() method, this creates a fresh matrix
          * that only represents scaling, without affecting rotation.
          *
-         * @example
+         * @code {.cpp}
          * Matrix33 scaleMatrix = Matrix33::CreateScale(Vector3D(2, 2, 2)); // Uniform scale by 2
          * Vector3D scaled = scaleMatrix * Vector3D(1, 1, 1); // Results in (2, 2, 2)
+         * @endcode 
          */
         static constexpr Matrix33 CreateScale(const Vector3D& scale)
         {
@@ -653,10 +670,11 @@ namespace SaturnMath
          *
          * @return The 3x3 identity matrix.
          *
-         * @example
+         * @code {.cpp}
          * Matrix33 identity = Matrix33::Identity();
          * Vector3D v(1, 2, 3);
          * Vector3D result = identity * v; // Same as v
+         * @endcode 
          */
         static consteval Matrix33 Identity()
         {

--- a/impl/mat33.hpp
+++ b/impl/mat33.hpp
@@ -3,7 +3,7 @@
 #include "vector3d.hpp"
 #include "trigonometry.hpp"
 
-namespace SaturnMath
+namespace SaturnMath::Types
 {
     /**
      * @brief 3x3 matrix for 3D transformations and rotations.

--- a/impl/mat33.hpp
+++ b/impl/mat33.hpp
@@ -601,9 +601,9 @@ namespace SaturnMath::Types
         bool TryInverse(Matrix33& out) const
         {
             const Fxp det = Determinant();
-            if (det == 0) return false;
+            if (det == 0.0) return false;
 
-            const Fxp invDet = Fxp(1) / det;
+            const Fxp invDet = 1.0 / det;
 
             // Calculate cofactors and adjugate matrix
             out.Row0.X = (Row1.Y * Row2.Z - Row1.Z * Row2.Y) * invDet;

--- a/impl/mat43.hpp
+++ b/impl/mat43.hpp
@@ -240,6 +240,40 @@ namespace SaturnMath::Types
             return Matrix33::operator*(vector);
         }
 
+        /**
+         * @brief Inverts the matrix.
+         *
+         * For orthogonal matrices (e.g., pure rotation matrices), the inverse is the transpose.
+         * This method computes the inverse by transposing the rotation part and negating the translation.
+         *
+         * @return The inverted matrix.
+         *
+         * @note This method assumes the matrix is orthogonal. For non-orthogonal matrices,
+         * this will not produce the correct inverse.
+         *
+         * @code {.cpp}
+         * Matrix43 transform = Matrix43::CreateTranslation(Vector3D(1, 2, 3));
+         * Matrix43 inverse = transform.Invert(); // Computes the inverse of the transformation matrix
+         * @endcode
+         */
+        Matrix43 Invert() const {
+            Matrix43 result;
+
+            // Invert the 3x3 rotation part (transpose for orthogonal matrices)
+            result.Row0 = Vector3D(Row0.X, Row1.X, Row2.X);
+            result.Row1 = Vector3D(Row0.Y, Row1.Y, Row2.Y);
+            result.Row2 = Vector3D(Row0.Z, Row1.Z, Row2.Z);
+
+            // Invert the translation part
+            result.Row3 = -Vector3D(
+                result.Row0.Dot(Row3),
+                result.Row1.Dot(Row3),
+                result.Row2.Dot(Row3)
+            );
+
+            return result;
+        }
+
         // Static creation methods
 
         /**

--- a/impl/mat43.hpp
+++ b/impl/mat43.hpp
@@ -443,12 +443,12 @@ namespace SaturnMath
             );
 
             // Extract rotation angles (Euler angles in XYZ order)
-            rotation.Y = Trigonometry::Asin(-rotMat.Row1.Z);
+            rotation.Y = Trigonometry::Asin(-rotMat.Row2.Z);
 
             // Check for gimbal lock
-            if (rotMat.Row1.Z < 0.999999 && rotMat.Row1.Z > -0.999999)
+            if (rotMat.Row2.Z < 0.999999 && rotMat.Row2.Z > -0.999999)
             {
-                rotation.X = Trigonometry::Atan2(rotMat.Row2.Z, rotMat.Row3.z);
+                rotation.X = Trigonometry::Atan2(rotMat.Row2.Z, rotMat.Row2.Z);
                 rotation.Z = Trigonometry::Atan2(rotMat.Row1.Y, rotMat.Row1.X);
             }
             else
@@ -556,6 +556,25 @@ namespace SaturnMath
                 Vector3D(0, 0, z),
                 Vector3D(0, 0, 0)
             );
+        }
+
+        /**
+         * @brief Creates a uniform scale matrix from a Vector3D.
+         * 
+         * This static method generates a 4x3 scale matrix that represents a transformation that scales 
+         * points uniformly along all axes by the specified scale factors from a Vector3D.
+         * 
+         * @param scale The Vector3D containing scale factors for all axes.
+         * 
+         * @return A new Matrix43 object representing the uniform scale transformation.
+         * 
+         * @code {.cpp}
+         * Matrix43 scaleMatrix = Matrix43::Scale(Vector3D(2, 2, 2)); // Scales by a factor of 2
+         * @endcode
+         */
+        static constexpr Matrix43 Scale(const Vector3D& scale)
+        {
+            return Scale(Fxp(scale.X), Fxp(scale.Y), Fxp(scale.Z));
         }
     };
 }

--- a/impl/mat43.hpp
+++ b/impl/mat43.hpp
@@ -2,7 +2,7 @@
 
 #include "mat33.hpp"
 
-namespace SaturnMath
+namespace SaturnMath::Types
 {
     /**
      * @brief 4x3 matrix optimized for 3D transformations.

--- a/impl/mat43.hpp
+++ b/impl/mat43.hpp
@@ -93,9 +93,10 @@ namespace SaturnMath
          * 
          * @return Reference to this matrix, allowing for method chaining.
          * 
-         * @example
+         * @code {.cpp}
          * Matrix43 matrix;
          * matrix.Translate(Vector3D(1, 0, 0)); // Moves the matrix by (1, 0, 0)
+         * @endcode 
          */
         Matrix43& Translate(const Vector3D& translation)
         {
@@ -114,8 +115,9 @@ namespace SaturnMath
          * 
          * @return Reference to this matrix after multiplication, allowing for method chaining.
          * 
-         * @example
+         * @code {.cpp}
          * Matrix43 result = matrix1 * matrix2; // Combines transformations of matrix1 and matrix2
+         * @endcode 
          */
         Matrix43& operator*=(const Matrix43& other)
         {
@@ -144,8 +146,9 @@ namespace SaturnMath
          * 
          * @return A new Matrix43 object that is the product of this matrix and the other matrix.
          * 
-         * @example
+         * @code {.cpp}
          * Matrix43 result = matrix1 * matrix2; // Creates a new matrix as the product of matrix1 and matrix2
+         * @endcode 
          */
         Matrix43 operator*(const Matrix43& other) const
         {
@@ -164,8 +167,9 @@ namespace SaturnMath
          * 
          * @return Reference to this matrix after multiplication, allowing for method chaining.
          * 
-         * @example
+         * @code {.cpp}
          * matrix *= rotationMatrix; // Updates the matrix with the rotation from rotationMatrix
+         * @endcode 
          */
         Matrix43& operator*=(const Matrix33& other)
         {
@@ -183,8 +187,9 @@ namespace SaturnMath
          * 
          * @return A new Matrix43 object that is the product of this matrix and the 3x3 matrix.
          * 
-         * @example
+         * @code {.cpp}
          * Matrix43 result = matrix * rotationMatrix; // Creates a new matrix as the product of matrix and rotationMatrix
+         * @endcode 
          */
         Matrix43 operator*(const Matrix33& other) const
         {
@@ -203,8 +208,9 @@ namespace SaturnMath
          * 
          * @return The transformed point as a Vector3D.
          * 
-         * @example
+         * @code {.cpp}
          * Vector3D transformedPoint = matrix.TransformPoint(Vector3D(1, 2, 3)); // Transforms the point (1, 2, 3)
+         * @endcode 
          */
         Vector3D TransformPoint(const Vector3D& point) const
         {
@@ -225,8 +231,9 @@ namespace SaturnMath
          * 
          * @return The transformed vector as a Vector3D.
          * 
-         * @example
+         * @code {.cpp}
          * Vector3D transformedVector = matrix.TransformVector(Vector3D(1, 0, 0)); // Transforms the vector (1, 0, 0)
+         * @endcode 
          */
         Vector3D TransformVector(const Vector3D& vector) const
         {
@@ -245,8 +252,9 @@ namespace SaturnMath
          * 
          * @return A new Matrix43 object representing the translation transformation.
          * 
-         * @example
+         * @code {.cpp}
          * Matrix43 translationMatrix = Matrix43::CreateTranslation(Vector3D(5, 0, 0)); // Translates by (5, 0, 0)
+         * @endcode 
          */
         static constexpr Matrix43 CreateTranslation(const Vector3D& translation)
         {
@@ -272,12 +280,13 @@ namespace SaturnMath
          * 
          * @return The billboard matrix that transforms points from world space to the billboard's local space.
          * 
-         * @example
+         * @code {.cpp}
          * Matrix43 billboardMatrix = Matrix43::CreateBillboard(
          *     Vector3D(0, 0, 0),   // Billboard position
          *     Vector3D(0, 0, 5),   // Camera position
          *     Vector3D(0, 1, 0)    // Up vector
          * );
+         * @endcode 
          * 
          * @note Ensure that the up vector is not collinear with the look vector to avoid undefined behavior.
          */
@@ -320,13 +329,14 @@ namespace SaturnMath
          *
          * @note This function assumes that the up vector is not collinear with the look vector.
          *
-         * @example
+         * @code {.cpp}
          * Matrix43 viewMatrix = Matrix43::CreateLookAt(
          *     Vector3D(0.0f, 0.0f, 5.0f),  // Eye position
          *     Vector3D(0.0f, 0.0f, 0.0f),  // Target position
          *     Vector3D::UnitY()            // Up vector
          * );
-         *
+         * @endcode 
+         * 
          * @details This function is used to create a view matrix that can be used to position a camera in 3D space.
          * The resulting matrix can be used to transform points from world space to the camera's local space.
          */
@@ -369,12 +379,13 @@ namespace SaturnMath
          * 
          * @return A new Matrix43 object representing the combined transformation.
          * 
-         * @example
+         * @code {.cpp}
          * Matrix43 transformMatrix = Matrix43::CreateTransform(
          *     Vector3D(1, 2, 3),                                  // Translation
          *     EulerAngles(Angle::Zero(), Angle::HalfPi(), Angle::Zero()),  // 90° rotation around Y axis
          *     Vector3D(2, 2, 2)                                   // Scale
          * );
+         * @endcode 
          */
         static Matrix43 CreateTransform(
             const Vector3D& translation,
@@ -457,8 +468,9 @@ namespace SaturnMath
          * 
          * @return A new Matrix43 object representing the identity transformation.
          * 
-         * @example
+         * @code {.cpp}
          * Matrix43 identityMatrix = Matrix43::Identity(); // Creates an identity matrix
+         * @endcode 
          */
         static consteval Matrix43 Identity()
         {
@@ -482,8 +494,9 @@ namespace SaturnMath
          * 
          * @return A new Matrix43 object representing the translation transformation.
          * 
-         * @example
+         * @code {.cpp}
          * Matrix43 translationMatrix = Matrix43::Translation(5, 0, 0); // Translates by (5, 0, 0)
+         * @endcode 
          */
         static constexpr Matrix43 Translation(const Fxp& x, const Fxp& y, const Fxp& z)
         {
@@ -505,8 +518,9 @@ namespace SaturnMath
          * 
          * @return A new Matrix43 object representing the uniform scale transformation.
          * 
-         * @example
+         * @code {.cpp}
          * Matrix43 scaleMatrix = Matrix43::Scale(2); // Scales by a factor of 2
+         * @endcode
          */
         static constexpr Matrix43 Scale(const Fxp& scale)
         {
@@ -530,8 +544,9 @@ namespace SaturnMath
          * 
          * @return A new Matrix43 object representing the non-uniform scale transformation.
          * 
-         * @example
+         * @code {.cpp}
          * Matrix43 nonUniformScaleMatrix = Matrix43::Scale(2, 1, 0.5); // Scales by (2, 1, 0.5)
+         * @endcode 
          */
         static constexpr Matrix43 Scale(const Fxp& x, const Fxp& y, const Fxp& z)
         {

--- a/impl/matrix_stack.hpp
+++ b/impl/matrix_stack.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "mat43.hpp"
-#include <stdexcept>
 
 namespace SaturnMath
 {

--- a/impl/matrix_stack.hpp
+++ b/impl/matrix_stack.hpp
@@ -2,7 +2,7 @@
 
 #include "mat43.hpp"
 
-namespace SaturnMath
+namespace SaturnMath::Types
 {
     class MatrixStack
     {

--- a/impl/plane.hpp
+++ b/impl/plane.hpp
@@ -24,7 +24,7 @@ namespace SaturnMath
         Fxp d;          /**< Signed distance from origin to plane */
 
         /** @brief Default constructor. Creates XY plane at origin. */
-        constexpr Plane() : normal(Vector3D::UnitZ()), d(0) {}
+        constexpr Plane() : normal(Vector3D::UnitZ()), d((int16_t)0) {}
 
         /**
          * @brief Creates plane from normal and distance.

--- a/impl/plane.hpp
+++ b/impl/plane.hpp
@@ -55,7 +55,8 @@ namespace SaturnMath
          */
         Plane(const Vector3D& a, const Vector3D& b, const Vector3D& c)
         {
-            normal = (b - a).Cross(c - a).Normalize();
+            Vector3D cross = (b - a).Cross(c - a);
+            normal = cross.Normalize();
             d = -normal.Dot(a);  // Negative because we want normal·X + d = 0
         }
 
@@ -91,7 +92,7 @@ namespace SaturnMath
          * 
          * @return Reference to this plane
          */
-        Plane& Normalize()
+        constexpr Plane& Normalize()
         {
             Fxp len = normal.Length();
             if (len > 0)

--- a/impl/plane.hpp
+++ b/impl/plane.hpp
@@ -2,7 +2,7 @@
 
 #include "vector3d.hpp"
 
-namespace SaturnMath
+namespace SaturnMath::Types
 {
     /**
      * @brief Infinite plane in 3D space defined by normal and distance.

--- a/impl/random.hpp
+++ b/impl/random.hpp
@@ -1,0 +1,61 @@
+#pragma once
+#include <stdint.h>
+
+namespace SaturnMath
+{
+    /** @brief Pseudo-Random number generator
+     * @note This generator uses Xorshift (see https://en.wikipedia.org/wiki/Xorshift)
+     */
+    class Random
+    {
+    private:
+
+        /** @brief Pseudo-Random number generator seed
+         */
+        uint32_t startState;
+
+        /** @brief Get next pseudo-random number
+         * @return Generated number
+         */
+        uint32_t GetNextPeriod()
+        {
+            this->startState ^= this->startState << 13;
+            this->startState ^= this->startState >> 17;
+            this->startState ^= this->startState << 5;
+            return this->startState;
+        }
+
+    public:
+    
+        /** @brief Construct a new pseudo-random number generator
+         * @param seed Starting seed
+         */
+        Random(uint32_t seed)
+        {
+            this->startState = seed;
+        }
+
+        /** @brief Destroy the pseudo-random number generator object
+         */
+        ~Random() { }
+
+        /** @brief Get next pseudo-random number
+         * @return Generated number in a full range
+         */
+        uint32_t GetNumber()
+        {
+            return this->GetNextPeriod();
+        }
+        
+        /** @brief Get next pseudo-random number
+         * @param from Inclusive start of the range
+         * @param to Inclusive end of the range
+         * @return Generated number in a range
+         */
+        int32_t GetNumber(int32_t from, int32_t to)
+        {
+            uint32_t number = this->GetNumber();
+            return from + (number % Math::Abs(to - from));
+        }
+    };
+}

--- a/impl/random.hpp
+++ b/impl/random.hpp
@@ -1,23 +1,27 @@
 #pragma once
 #include <stdint.h>
+#include <type_traits>
 
 namespace SaturnMath
 {
     /** @brief Pseudo-Random number generator
      * @note This generator uses Xorshift (see https://en.wikipedia.org/wiki/Xorshift)
+     * @tparam T Integral type for random number generation
      */
+    template<typename T>
     class Random
     {
     private:
+        static_assert(std::is_integral_v<T>, "T must be an integral type");
 
         /** @brief Pseudo-Random number generator seed
          */
-        uint32_t startState;
+        T startState;
 
         /** @brief Get next pseudo-random number
          * @return Generated number
          */
-        uint32_t GetNextPeriod()
+        T GetNextPeriod()
         {
             this->startState ^= this->startState << 13;
             this->startState ^= this->startState >> 17;
@@ -30,7 +34,7 @@ namespace SaturnMath
         /** @brief Construct a new pseudo-random number generator
          * @param seed Starting seed
          */
-        Random(uint32_t seed)
+        Random(T seed)
         {
             this->startState = seed;
         }
@@ -42,7 +46,7 @@ namespace SaturnMath
         /** @brief Get next pseudo-random number
          * @return Generated number in a full range
          */
-        uint32_t GetNumber()
+        T GetNumber()
         {
             return this->GetNextPeriod();
         }
@@ -52,10 +56,10 @@ namespace SaturnMath
          * @param to Inclusive end of the range
          * @return Generated number in a range
          */
-        int32_t GetNumber(int32_t from, int32_t to)
+        T GetNumber(T from, T to)
         {
-            uint32_t number = this->GetNumber();
-            return from + (number % Math::Abs(to - from));
+            T number = this->GetNumber();
+            return from + (number % std::abs(to - from));
         }
     };
 }

--- a/impl/shape.hpp
+++ b/impl/shape.hpp
@@ -3,7 +3,7 @@
 #include "vector3d.hpp"
 #include "plane.hpp"
 
-namespace SaturnMath
+namespace SaturnMath::Types
 {
     /**
      * @brief Base class for geometric shapes.

--- a/impl/sphere.hpp
+++ b/impl/sphere.hpp
@@ -47,29 +47,23 @@ namespace SaturnMath::Types
 
         /**
          * @brief Tests if a point is inside the sphere.
-         * 
-         * @tparam P Precision level for calculation (default is Precision::Standard)
-         * @param point Point to test
-         * @return true if the point is inside or on the surface of the sphere
+         * @param point Point to test.
+         * @return true if the point is inside or on the surface of the sphere.
          */
-        template<Precision P = Precision::Standard>
-        constexpr bool Contains(const Vector3D& point) const
-        {
-            return (point - position).Length<P>().Square() <= radius.Square();
+        bool Contains(const Vector3D& point) const {
+            Fxp distanceSquared = (point - GetPosition()).LengthSquared();
+            return distanceSquared <= radius * radius;
         }
 
         /**
          * @brief Tests intersection with another sphere.
-         * 
-         * @tparam P Precision level for calculation (default is Precision::Standard)
-         * @param other Sphere to test against
-         * @return true if spheres overlap
+         * @param other Sphere to test against.
+         * @return true if spheres overlap.
          */
-        template<Precision P = Precision::Standard>
-        constexpr bool Intersects(const Sphere& other) const
-        {
-            Fxp radiusSum = radius + other.radius;
-            return (other.position - position).Length<P>().Square() <= radiusSum.Square();
+        bool Intersects(const Sphere& other) const {
+            Fxp distanceSquared = (GetPosition() - other.GetPosition()).LengthSquared();
+            Fxp sumOfRadii = radius + other.GetRadius();
+            return distanceSquared <= sumOfRadii * sumOfRadii;
         }
 
         /**

--- a/impl/sphere.hpp
+++ b/impl/sphere.hpp
@@ -4,7 +4,7 @@
 #include "plane.hpp"
 #include "aabb.hpp"
 
-namespace SaturnMath
+namespace SaturnMath::Types
 {
     /**
      * @brief Perfect sphere defined by center and radius.

--- a/impl/trigonometry.hpp
+++ b/impl/trigonometry.hpp
@@ -4,7 +4,6 @@
 #include "angle.hpp"
 #include <type_traits>
 #include <utility>
-#include <stdexcept>
 
 namespace SaturnMath
 {
@@ -234,25 +233,7 @@ namespace SaturnMath
          * - Covers practical range for most applications
          * - Memory efficient by serving both sinh and cosh functions
          */
-        static constexpr LookupCache<uint16_t, 0x7FF, 11> sinhTable[] = {
-            {0, 0},          // sinh(0) = 0
-            {4096, 4198},    // sinh(0.25) ≈ 0.2526
-            {8192, 8599},    // sinh(0.5) ≈ 0.5211
-            {12288, 13271},  // sinh(0.75) ≈ 0.8687
-            {16384, 18288},  // sinh(1.0) ≈ 1.1752
-            {20480, 23815},  // sinh(1.25) ≈ 1.6019
-            {24576, 29996},  // sinh(1.5) ≈ 2.1293
-            {28672, 36978},  // sinh(1.75) ≈ 2.7622
-            {32768, 44900},  // sinh(2.0) ≈ 3.6269
-            {36864, 54000},  // sinh(2.25) ≈ 4.7017
-            {40960, 64500},  // sinh(2.5) ≈ 6.0502
-            {45056, 76600},  // sinh(2.75) ≈ 7.7097
-            {49152, 90500},  // sinh(3.0) ≈ 10.0179
-            {53248, 106400}, // sinh(3.25) ≈ 12.8482
-            {57344, 124500}, // sinh(3.5) ≈ 16.5425
-            {61440, 144900}, // sinh(3.75) ≈ 21.1910
-            {65535, 167800}, // sinh(4.0) ≈ 27.2899
-            {0x4000, 0} };    // End marker
+        static constexpr LookupCache<uint16_t, 0x7FF, 11> sinhTable[] = {/* Todo: Add proper table values */};    // End marker
 
     public:
         /**
@@ -601,41 +582,4 @@ namespace SaturnMath
         }
         /** @} */
     };
-
-    /**
-     * @name Free Function Wrappers
-     * Convenient free function wrappers for trigonometric operations.
-     * @{
-     */
-
-    /** @copydoc Trigonometry::Sin */
-    inline constexpr Fxp Sin(const Angle& angle) { return Trigonometry::Sin(angle); }
-
-    /** @copydoc Trigonometry::Cos */
-    inline constexpr Fxp Cos(const Angle& angle) { return Trigonometry::Cos(angle); }
-
-    /** @copydoc Trigonometry::Tan */
-    inline constexpr Fxp Tan(const Angle& angle) { return Trigonometry::Tan(angle); }
-
-    /** @copydoc Trigonometry::Atan2 */
-    inline constexpr Angle Atan2(const Fxp& y, const Fxp& x) { return Trigonometry::Atan2(y, x); }
-
-    /** @copydoc Trigonometry::Asin */
-    inline constexpr Angle Asin(const Fxp& value) { return Trigonometry::Asin(value); }
-
-    /** @copydoc Trigonometry::Acos */
-    inline constexpr Angle Acos(const Fxp& value) { return Trigonometry::Acos(value); }
-
-    /** @copydoc Trigonometry::Sinh */
-    inline constexpr Fxp Sinh(const Fxp& value) { return Trigonometry::Sinh(value); }
-
-    /** @copydoc Trigonometry::Cosh */
-    inline constexpr Fxp Cosh(const Fxp& value) { return Trigonometry::Cosh(value); }
-
-    /** @copydoc Trigonometry::Tanh */
-    inline constexpr Fxp Tanh(const Fxp& value) { return Trigonometry::Tanh(value); }
-
-
-    static constexpr auto test = Asin(0.2);
-    /** @} */
 }

--- a/impl/trigonometry.hpp
+++ b/impl/trigonometry.hpp
@@ -420,15 +420,15 @@ namespace SaturnMath
          */
         static constexpr Angle Atan2(const Fxp& y, const Fxp& x)
         {
-            uint16_t result = x < 0 ?
-                (y < 0 ? Angle::Pi().RawValue() : -Angle::Pi().RawValue()) : 0;
+            uint16_t result = x < 0.0 ?
+                (y < 0.0 ? Angle::Pi().RawValue() : -Angle::Pi().RawValue()) : 0;
 
             int32_t divResult;
 
             if (x.Abs() < y.Abs())
             {
                 divResult = (x / y).RawValue();
-                result += divResult < 0 ? -Angle::HalfPi().RawValue() : Angle::HalfPi().RawValue();
+                result += divResult < 0.0 ? -Angle::HalfPi().RawValue() : Angle::HalfPi().RawValue();
             }
             else
             {

--- a/impl/trigonometry.hpp
+++ b/impl/trigonometry.hpp
@@ -7,6 +7,7 @@
 
 namespace SaturnMath
 {
+    using namespace SaturnMath::Types;
     /**
      * @brief Core trigonometric functionality using fixed-point arithmetic
      *

--- a/impl/utils.hpp
+++ b/impl/utils.hpp
@@ -11,9 +11,58 @@ namespace SaturnMath
     {
     public:
         /**
+         * @brief Get absolute value
+         * 
+         * @details Works with any type that supports comparison operators.
+         *
+		 * @tparam ValueType Type of the value
+		 * @param value Numeric value
+		 * @return Absolute value
+         */
+		template<typename ValueType>
+		constexpr static ValueType Abs(const ValueType& value)
+		{
+			return value < 0 ? -value : value;
+		}
+
+		/**
+         * @brief Get maximum value of two values
+		 * 
+         * @details Works with any type that supports comparison operators.
+         *
+         * @tparam ValueType Type of the value
+		 * 
+         * @param first First value
+		 * @param second Second value
+         * @return Maximum value
+		 */
+		template<typename ValueType>
+		constexpr static ValueType Max(const ValueType& first, const ValueType& second)
+		{
+			return first > second ? first : second;
+		}
+
+        /**
+		 * @brief Get minimum value of two values
+         * 
+         * @details Works with any type that supports comparison operators.
+         *
+		 * @tparam ValueType Type of the value
+         * 
+		 * @param first First value
+		 * @param second Second value
+		 * @return Minimum value
+         */
+		template<typename ValueType>
+		constexpr static ValueType Min(const ValueType& first, const ValueType& second)
+		{
+			return first < second ? first : second;
+		}
+
+        /**
          * @brief Clamps a value between min and max bounds.
          *
-         * Works with any type that supports comparison operators.
+         * @details Works with any type that supports comparison operators.
          *
          * @tparam T Type of the values
          * @param value Value to clamp

--- a/impl/utils.hpp
+++ b/impl/utils.hpp
@@ -5,107 +5,100 @@
 namespace SaturnMath
 {
     /**
-     * @brief Generic utility functions and specialized math operations
+     * @brief Get absolute value
+     *
+     * @details Works with any type that supports comparison operators.
+     *
+     * @tparam ValueType Type of the value
+     * @param value Numeric value
+     * @return Absolute value
      */
-    class Utils
+    template<typename ValueType>
+    constexpr static ValueType Abs(const ValueType& value)
+    {
+        return value < 0 ? -value : value;
+    }
+
+    /**
+     * @brief Get maximum value of two values
+     *
+     * @details Works with any type that supports comparison operators.
+     *
+     * @tparam ValueType Type of the value
+     *
+     * @param first First value
+     * @param second Second value
+     * @return Maximum value
+     */
+    template<typename ValueType>
+    constexpr static ValueType Max(const ValueType& first, const ValueType& second)
+    {
+        return first > second ? first : second;
+    }
+
+    /**
+     * @brief Get minimum value of two values
+     *
+     * @details Works with any type that supports comparison operators.
+     *
+     * @tparam ValueType Type of the value
+     *
+     * @param first First value
+     * @param second Second value
+     * @return Minimum value
+     */
+    template<typename ValueType>
+    constexpr static ValueType Min(const ValueType& first, const ValueType& second)
+    {
+        return first < second ? first : second;
+    }
+
+    /**
+     * @brief Clamps a value between min and max bounds.
+     *
+     * @details Works with any type that supports comparison operators.
+     *
+     * @tparam T Type of the values
+     * @param value Value to clamp
+     * @param min Minimum allowed value
+     * @param max Maximum allowed value
+     * @return Clamped value
+     */
+    template<typename T>
+    static constexpr T Clamp(const T& value, const T& min, const T& max)
+    {
+        return value < min ? min : (value > max ? max : value);
+    }
+
+    /**
+     * @brief Integer-specific utility functions optimized for performance
+     */
+    class Integer final
     {
     public:
         /**
-         * @brief Get absolute value
-         * 
-         * @details Works with any type that supports comparison operators.
+         * @brief Fast integer square root approximation with ~6% error.
          *
-		 * @tparam ValueType Type of the value
-		 * @param value Numeric value
-		 * @return Absolute value
+         * Binary search approximation supporting full uint32_t range.
+         * Maximum 15 iterations after initial right shift by 2.
+         * Ideal for games where integer precision is sufficient
+         * and performance matters more than perfect accuracy.
+         *
+         * @param src The 32-bit integer value.
+         * @return Approximate square root as whole number.
          */
-		template<typename ValueType>
-		constexpr static ValueType Abs(const ValueType& value)
-		{
-			return value < 0 ? -value : value;
-		}
-
-		/**
-         * @brief Get maximum value of two values
-		 * 
-         * @details Works with any type that supports comparison operators.
-         *
-         * @tparam ValueType Type of the value
-		 * 
-         * @param first First value
-		 * @param second Second value
-         * @return Maximum value
-		 */
-		template<typename ValueType>
-		constexpr static ValueType Max(const ValueType& first, const ValueType& second)
-		{
-			return first > second ? first : second;
-		}
-
-        /**
-		 * @brief Get minimum value of two values
-         * 
-         * @details Works with any type that supports comparison operators.
-         *
-		 * @tparam ValueType Type of the value
-         * 
-		 * @param first First value
-		 * @param second Second value
-		 * @return Minimum value
-         */
-		template<typename ValueType>
-		constexpr static ValueType Min(const ValueType& first, const ValueType& second)
-		{
-			return first < second ? first : second;
-		}
-
-        /**
-         * @brief Clamps a value between min and max bounds.
-         *
-         * @details Works with any type that supports comparison operators.
-         *
-         * @tparam T Type of the values
-         * @param value Value to clamp
-         * @param min Minimum allowed value
-         * @param max Maximum allowed value
-         * @return Clamped value
-         */
-        template<typename T>
-        static constexpr T Clamp(const T& value, const T& min, const T& max)
+        static constexpr uint32_t FastSqrt(uint32_t src)
         {
-            return value < min ? min : (value > max ? max : value);
-        }
+            uint32_t baseEstimation = 1;
+            uint32_t estimation = src >> 2;
 
-        /**
-         * @brief Integer-specific utility functions optimized for performance
-         */
-        class Integer
-        {
-        public:
-            /**
-             * @brief Fast integer square root approximation with ~6% error.
-             *
-             * Binary search approximation supporting full uint32_t range.
-             * Maximum 15 iterations after initial right shift by 2.
-             * Ideal for games where integer precision is sufficient
-             * and performance matters more than perfect accuracy.
-             *
-             * @param src The 32-bit integer value.
-             * @return Approximate square root as whole number.
-             */
-            static constexpr uint32_t FastSqrt(uint32_t src)
+            while (baseEstimation < estimation)
             {
-                uint32_t baseEstimation = 1;
-                uint32_t estimation = src >> 2;
-
-                while (baseEstimation < estimation)
-                {
-                    estimation >>= 1;
-                    baseEstimation <<= 1;
-                }
-
-                return baseEstimation + estimation;
+                estimation >>= 1;
+                baseEstimation <<= 1;
             }
-        };
+
+            return baseEstimation + estimation;
+        }
     };
 }

--- a/impl/vector2d.hpp
+++ b/impl/vector2d.hpp
@@ -80,7 +80,7 @@ namespace SaturnMath::Types
             return result;
         }
 
-                /**
+        /**
          * @brief Helper function to perform assembly-level dot product calculation and accumulation
          * @param first First vector
          * @param second Second vector
@@ -213,6 +213,24 @@ namespace SaturnMath::Types
         }
 
         /**
+         * @brief Calculate the squared length of the vector.
+         * @return The squared length as an Fxp value.
+         * @details Useful for comparisons where the actual length is not needed.
+         * 
+         * Example usage:
+         * @code
+         * Vector2D v1(1, 2);
+         * Vector2D v2(4, 6);
+         * if (v1.LengthSquared() < v2.LengthSquared()) {
+         *     // v1 is shorter than v2
+         * }
+         * @endcode
+         */
+        constexpr Fxp LengthSquared() const {
+            return Dot(*this);
+        }
+
+        /**
          * @brief Normalize the vector
          * @tparam P Precision level for calculation
          * @return Normalized vector
@@ -224,6 +242,23 @@ namespace SaturnMath::Types
             if (length != 0)
                 return Vector2D(X / length, Y / length);
             return Vector2D();
+        }
+
+        /**
+         * @brief Calculate the Euclidean distance from this vector to another vector.
+         * @param other The other vector to calculate the distance to.
+         * @return The distance as an Fxp value.
+         * @details Computes the distance using the formula: sqrt((X - other.X)^2 + (Y - other.Y)^2).
+         * 
+         * Example usage:
+         * @code
+         * Vector2D v1(1, 2);
+         * Vector2D v2(4, 6);
+         * Fxp distance = v1.DistanceTo(v2); // Computes distance between (1, 2) and (4, 6)
+         * @endcode
+         */
+        constexpr Fxp DistanceTo(const Vector2D& other) const {
+            return (*this - other).Length();
         }
 
         // Unit vectors and directional methods

--- a/impl/vector2d.hpp
+++ b/impl/vector2d.hpp
@@ -315,6 +315,42 @@ namespace SaturnMath
         }
 
         /**
+         * @brief Division operator.
+         * @param scalar The scalar to divide by.
+         * @return The result of the division.
+         */
+        constexpr Vector2D operator/=(const Fxp& scalar)
+        {
+            X /= scalar;
+            Y /= scalar;
+            return *this;
+        }
+
+        /**
+         * @brief Addition operator.
+         * @param vec The vector to add.
+         * @return The result of the addition.
+         */
+        constexpr Vector2D operator+=(const Vector2D& vec)
+        {
+            X += vec.X;
+            Y += vec.Y;
+            return *this;
+        }
+
+        /**
+         * @brief Subtraction operator.
+         * @param vec The vector to subtract.
+         * @return The result of the subtraction.
+         */
+        constexpr Vector2D operator-=(const Vector2D& vec)
+        {
+            X -= vec.X;
+            Y -= vec.Y;
+            return *this;
+        }
+
+        /**
          * @brief Scaling operator.
          * @param scalar The scalar to multiply with.
          * @return The result of the scaling.
@@ -354,6 +390,82 @@ namespace SaturnMath
         constexpr Vector2D operator/(const Fxp& scalar) const
         {
             return Vector2D(X / scalar, Y / scalar);
+        }
+        
+        // Unary operators
+        /**
+         * @brief Unary negation operator.
+         * @return A new Vec3 object with negated coordinates.
+         */
+        constexpr Vector2D operator-() const
+        {
+            return Vector2D(-X, -Y);
+        }
+
+        // Comparison operators
+        /**
+         * @brief Check if two Vec3 objects are not equal.
+         * @param vec The Vec3 object to compare.
+         * @return True if not equal, false otherwise.
+         */
+        constexpr bool operator!=(const Vector2D& vec) const
+        {
+            return X != vec.X && Y != vec.Y;
+        }
+
+        /**
+         * @brief Check if two Vec3 objects are not equal.
+         * @param vec The Vec3 object to compare.
+         * @return True if not equal, false otherwise.
+         */
+        constexpr bool operator==(const Vector2D& vec) const
+        {
+            return X == vec.X && Y == vec.Y;
+        }
+
+        // Bitwise shift operators
+        /**
+         * @brief Bitwise right shift operator.
+         * @param shiftAmount The number of positions to shift.
+         * @return The resulting Vec3 object.
+         */
+        constexpr Vector2D operator>>(const size_t& shiftAmount)
+        {
+            return Vector3D(X >> shiftAmount, Y >> shiftAmount);
+        }
+
+        /**
+         * @brief Bitwise right shift assignment operator.
+         * @param shiftAmount The number of positions to shift.
+         * @return Reference to the modified Vec3 object.
+         */
+        constexpr Vector2D& operator>>=(const size_t& shiftAmount)
+        {
+            X >>= shiftAmount;
+            Y >>= shiftAmount;
+            return *this;
+        }
+
+        /**
+         * @brief Bitwise left shift operator.
+         * @param shiftAmount The number of positions to shift.
+         * @return The resulting Vec3 object.
+         */
+        constexpr Vector2D operator<<(const size_t& shiftAmount)
+        {
+            return Vector2D(X << shiftAmount, Y << shiftAmount);
+        }
+
+        /**
+         * @brief Bitwise left shift assignment operator.
+         * @param shiftAmount The number of positions to shift.
+         * @return Reference to the modified Vec3 object.
+         */
+        constexpr Vector2D& operator<<=(const size_t& shiftAmount)
+        {
+            X <<= shiftAmount;
+            Y <<= shiftAmount;
+            return *this;
         }
     };
 }

--- a/impl/vector2d.hpp
+++ b/impl/vector2d.hpp
@@ -4,7 +4,7 @@
 #include "precision.hpp"
 #include "sort_order.hpp"
 
-namespace SaturnMath
+namespace SaturnMath::Types
 {
     /**
      * @brief A struct for two-dimensional fixed-point vector arithmetic operations.

--- a/impl/vector2d.hpp
+++ b/impl/vector2d.hpp
@@ -431,7 +431,7 @@ namespace SaturnMath
          */
         constexpr Vector2D operator>>(const size_t& shiftAmount)
         {
-            return Vector3D(X >> shiftAmount, Y >> shiftAmount);
+            return Vector2D(X >> shiftAmount, Y >> shiftAmount);
         }
 
         /**

--- a/impl/vector3d.hpp
+++ b/impl/vector3d.hpp
@@ -246,7 +246,7 @@ namespace SaturnMath
                     0.38928148272372454, // Beta
                     0.2987061876143797   // Gamma
                 );
-                return Abs().Sort<SortOrder::Descending>().Dot(alphaBetaGamma);
+                return alphaBetaGamma.Dot(Abs().Sort<SortOrder::Descending>());
             }
             else
             {

--- a/impl/vector3d.hpp
+++ b/impl/vector3d.hpp
@@ -231,6 +231,24 @@ namespace SaturnMath::Types
         }
 
         /**
+         * @brief Calculate the squared length of the vector.
+         * @return The squared length as an Fxp value.
+         * @details Useful for comparisons where the actual length is not needed.
+         * 
+         * Example usage:
+         * @code
+         * Vector3D v1(1, 2, 3);
+         * Vector3D v2(4, 6, 8);
+         * if (v1.LengthSquared() < v2.LengthSquared()) {
+         *     // v1 is shorter than v2
+         * }
+         * @endcode
+         */
+        constexpr Fxp LengthSquared() const {
+            return Dot(*this);
+        }
+
+        /**
          * @brief Calculate the length of the vector
          * @tparam P Precision level for calculation
          * @return Length of the vector
@@ -285,6 +303,23 @@ namespace SaturnMath::Types
             const Vector3D edge1 = vertexB - vertexA;
             const Vector3D edge2 = vertexC - vertexA;
             return edge1.Cross(edge2).Normalize<P>();
+        }
+
+        /**
+         * @brief Calculate the Euclidean distance from this vector to another vector.
+         * @param other The other vector to calculate the distance to.
+         * @return The distance as an Fxp value.
+         * @details Computes the distance using the formula: sqrt((X - other.X)^2 + (Y - other.Y)^2 + (Z - other.Z)^2).
+         * 
+         * Example usage:
+         * @code
+         * Vector3D v1(1, 2, 3);
+         * Vector3D v2(4, 6, 8);
+         * Fxp distance = v1.DistanceTo(v2); // Computes distance between (1, 2, 3) and (4, 6, 8)
+         * @endcode
+         */
+        constexpr Fxp DistanceTo(const Vector3D& other) const {
+            return (*this - other).Length();
         }
 
         // Scalar multiplication and division

--- a/impl/vector3d.hpp
+++ b/impl/vector3d.hpp
@@ -301,6 +301,18 @@ namespace SaturnMath
         }
 
         /**
+         * @brief Divide each coordinate by a scalar value.
+         * @param fxp The scalar value to divide by.
+         * @return The resulting Vec3 object.
+         */
+        constexpr Vector3D operator/=(const Fxp& fxp)
+        {
+            Vector2D::operator*=(fxp);
+            Z *= fxp;
+            return *this;
+        }
+
+        /**
          * @brief Multiply each coordinate by a scalar value.
          * @param scalar The scalar value to multiply by.
          * @return The resulting Vec3 object.
@@ -377,6 +389,16 @@ namespace SaturnMath
         constexpr bool operator!=(const Vector3D& vec) const
         {
             return X != vec.X && Y != vec.Y && Z != vec.Z;
+        }
+
+        /**
+         * @brief Check if two Vec3 objects are not equal.
+         * @param vec The Vec3 object to compare.
+         * @return True if not equal, false otherwise.
+         */
+        constexpr bool operator==(const Vector3D& vec) const
+        {
+            return X == vec.X && Y == vec.Y && Z == vec.Z;
         }
 
         // Bitwise shift operators
@@ -481,22 +503,6 @@ namespace SaturnMath
             Y -= vec.Y;
             Z -= vec.Z;
             return *this;
-        }
-
-        void test()
-        {
-            static constexpr Vector3D v1(1, 0, 0), v2(1, 0, 0);  // Unit vectors along X
-            static constexpr Vector3D v3(0, 1, 0), v4(0, 1, 0);  // Unit vectors along Y
-            static constexpr Vector3D v5(0, 0, 1), v6(0, 0, 1);  // Unit vectors along Z
-
-
-            // Computes (v1·v2) + (v3·v4) + (v5·v6) = 1 + 1 + 1 = 3
-            // All calculations done in parallel using Saturn's MAC registers
-            static constexpr auto result = Vector3D::MultiDotAccumulate(
-                std::pair{ v1, v2 },
-                std::pair{ v3, v4 },
-                std::pair{ v5, v6 }
-            ).ToFloat();
         }
     };
 }

--- a/impl/vector3d.hpp
+++ b/impl/vector3d.hpp
@@ -5,7 +5,7 @@
 #include "precision.hpp"
 #include "sort_order.hpp"
 
-namespace SaturnMath
+namespace SaturnMath::Types
 {
     /**
      * @brief A struct for three-dimensional fixed-point vector arithmetic operations.

--- a/saturn_math.hpp
+++ b/saturn_math.hpp
@@ -1,29 +1,29 @@
 #pragma once
 
 // Fixed-point arithmetic header
-#include "impl/fxp.hpp"
+#include <impl/fxp.hpp>
 
 // Vector and matrix headers
-#include "impl/vector2d.hpp"
-#include "impl/vector3d.hpp"
-#include "impl/mat33.hpp"
-#include "impl/mat43.hpp"
+#include <impl/vector2d.hpp>
+#include <impl/vector3d.hpp>
+#include <impl/mat33.hpp>
+#include <impl/mat43.hpp>
 
 // Shape headers
-#include "impl/plane.hpp"
-#include "impl/aabb.hpp"
-#include "impl/sphere.hpp"
+#include <impl/plane.hpp>
+#include <impl/aabb.hpp>
+#include <impl/sphere.hpp>
 
 // Math utility headers
-#include "impl/trigonometry.hpp"
+#include <impl/trigonometry.hpp>
 
 // Additional utility and precision headers
-#include "impl/utils.hpp"
-#include "impl/interpolation.hpp"
-#include "impl/angle.hpp"
-#include "impl/sort_order.hpp"
-#include "impl/precision.hpp"
+#include <impl/utils.hpp>
+#include <impl/interpolation.hpp>
+#include <impl/angle.hpp>
+#include <impl/sort_order.hpp>
+#include <impl/precision.hpp>
 
 // Other headers
-#include "impl/frustum.hpp"
-#include "impl/matrix_stack.hpp"
+#include <impl/frustum.hpp>
+#include <impl/matrix_stack.hpp>

--- a/saturn_math.hpp
+++ b/saturn_math.hpp
@@ -19,6 +19,7 @@
 
 // Additional utility and precision headers
 #include <impl/utils.hpp>
+#include <impl/random.hpp>
 #include <impl/interpolation.hpp>
 #include <impl/angle.hpp>
 #include <impl/sort_order.hpp>


### PR DESCRIPTION
Core changes:
- Added templated Abs, Max, Min to utils.hpp
- Added missing operators to vector3d.hpp
- Added missing operators to vector2d.hpp
- Added ToDouble() for fxp
- Changed ToFloat() to give float instead of double
- Fixed ToFloat(), ToDouble(), ToInt() not being const
- Fixed documentation errors
- Removed stdexcept include from matrix matrix_stack.hpp