### PR TITLE
fix: Fxp::Ceil and Fxp::Floor for integral values

### DIFF
--- a/impl/fxp.hpp
+++ b/impl/fxp.hpp
@@ -307,12 +307,9 @@ namespace SaturnMath::Types
          */
         constexpr Fxp Floor() const
         {
-            // For positive values, truncate the fraction
-            // For negative values with a fraction, subtract 1 from the integer part
-            if (value >= 0)
-                return TruncateFraction();
-            else
-                return BuildRaw((value - 0x1000) & 0xFFFF0000);
+            // Masking away the fractional bits yields correct floor semantics in two's complement
+            // for both positive and negative values.
+            return BuildRaw(value & 0xFFFF0000);
         }
 
         /**
@@ -324,11 +321,15 @@ namespace SaturnMath::Types
          */
         constexpr Fxp Ceil() const
         {
-            // If positive with a fraction, add 1 to the integer part
-            if (value >= 0)
-                return BuildRaw((value + 0x10000) & 0xFFFF0000);
-            else
-                return TruncateFraction();
+            const int32_t truncated = value & 0xFFFF0000;
+            const int32_t frac = value & 0x0000FFFF;
+
+            // If already integral, return unchanged.
+            if (frac == 0)
+                return BuildRaw(truncated);
+
+            // Otherwise move to the next integer toward +infinity.
+            return BuildRaw(truncated + 0x00010000);
                 
         }
 

--- a/tests/test_fxp.hpp
+++ b/tests/test_fxp.hpp
@@ -332,6 +332,12 @@ namespace SaturnMath::Tests
             constexpr Fxp a(5.5);
             constexpr Fxp b(-3.25);
 
+            constexpr Fxp c(1.0);
+            constexpr Fxp d(-1.0);
+
+            static_assert(c.Ceil() == 1, "Ceil of integeral positive should stay the same");
+            static_assert(d.Floor() == -1, "Floor of integeral negative should stay the same");
+
             // Absolute value
             static_assert(a.Abs() == a, "Abs of positive should be unchanged");
             static_assert(b.Abs() == -b, "Abs of negative should be positive");
@@ -578,13 +584,13 @@ namespace SaturnMath::Tests
             // For exact integers, Floor and Ceil should return the same value
             static_assert(c.Floor() == 7, "Floor of positive integer value");
             // When there's no fractional part, Ceil returns the same value
-            static_assert(c.Ceil() == 8, "Ceil of positive integer value");
+            static_assert(c.Ceil() == 7, "Ceil of positive integer value");
             static_assert(c.Round() == 7, "Round of positive integer value");
 
             // Test exact negative integers
             constexpr Fxp d(-7.0);
             // For negative integers, Floor should return the same value
-            static_assert(d.Floor() == -8, "Floor of negative integer value");
+            static_assert(d.Floor() == -7, "Floor of negative integer value");
             static_assert(d.Ceil() == -7, "Ceil of negative integer value");
             static_assert(d.Round() == -7, "Round of negative integer value");
 

--- a/tests/test_fxp.hpp
+++ b/tests/test_fxp.hpp
@@ -332,12 +332,6 @@ namespace SaturnMath::Tests
             constexpr Fxp a(5.5);
             constexpr Fxp b(-3.25);
 
-            constexpr Fxp c(1.0);
-            constexpr Fxp d(-1.0);
-
-            static_assert(c.Ceil() == 1, "Ceil of integeral positive should stay the same");
-            static_assert(d.Floor() == -1, "Floor of integeral negative should stay the same");
-
             // Absolute value
             static_assert(a.Abs() == a, "Abs of positive should be unchanged");
             static_assert(b.Abs() == -b, "Abs of negative should be positive");


### PR DESCRIPTION
Fixes incorrect behavior of `Fxp::Ceil()` and `Fxp::Floor()` when dealing with exact integer values.

## Problem
- `Fxp::Ceil(1.0)` was returning `2` instead of `1`
- `Fxp::Floor(-1.0)` was returning `-2` instead of `-1`
- This caused failing `static_assert`s in the test suite

## Solution
- **`Fxp::Floor()`**: Simplified to mask fractional bits (`value & 0xFFFF0000`), which correctly handles both positive and negative values in two's complement
- **`Fxp::Ceil()`**: Only adds 1 when fractional part is present; returns unchanged value for exact integers
- **Tests**: Fixed inconsistent assertions and removed duplicate test cases already covered in `TestRoundingConsistency`

## Changes
- `impl/fxp.hpp`: Fixed `Floor()` and `Ceil()` implementations
- `tests/test_fxp.hpp`: Corrected assertions and removed duplicates

## Verification
All `static_assert`s now pass for:
- `Ceil(7.0) == 7`
- `Floor(-7.0) == -7`
- Fractional values still round correctly (e.g., `Ceil(5.25) == 6`, `Floor(-3.25) == -4`)

## Files Changed
- `impl/fxp.hpp`
- `tests/test_fxp.hpp`